### PR TITLE
Create a new version for a space efficient monoid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dist
+.stack-work
+stack.yaml

--- a/average.cabal
+++ b/average.cabal
@@ -21,7 +21,6 @@ source-repository head
 library
     build-depends:
         base            >= 4 && < 5,
-        vector-space    >= 0.8.7 && < 0.11,
         semigroups      >= 0.13.0.1 && < 1
     hs-source-dirs:     src
     default-language:   Haskell2010
@@ -37,7 +36,6 @@ test-suite spec
     build-depends:
         average,
         base            >= 4 && < 5,
-        vector-space    >= 0.8.7 && < 0.11,
         semigroups      >= 0.13.0.1 && < 1,
         QuickCheck      >= 2 && < 3,
         hspec           >= 2.4 && < 2.5,

--- a/average.cabal
+++ b/average.cabal
@@ -1,13 +1,13 @@
 
 name:               average
-version:            0.6
+version:            1.0
 cabal-version:      >= 1.10
 author:             Hans Hoglund
 maintainer:         Hans Hoglund <hans@hanshoglund.se>
 license:            BSD3
 license-file:       COPYING
 synopsis:           An average (arithmetic mean) monoid.
-category:           
+category:
 tested-with:        GHC
 build-type:         Simple
 

--- a/average.cabal
+++ b/average.cabal
@@ -28,3 +28,18 @@ library
     exposed-modules:
         Data.Monoid.Average
 
+test-suite spec
+    type: exitcode-stdio-1.0
+    main-is: Spec.hs
+    hs-source-dirs:
+          tests
+    ghc-options: -Wall -rtsopts -O0
+    build-depends:
+        average,
+        base            >= 4 && < 5,
+        vector-space    >= 0.8.7 && < 0.11,
+        semigroups      >= 0.13.0.1 && < 1,
+        QuickCheck      >= 2 && < 3,
+        hspec           >= 2.4 && < 2.5,
+        hspec-checkers  >= 0.1 && < 0.2,
+        checkers        >= 0.4 && < 0.5

--- a/src/Data/Monoid/Average.hs
+++ b/src/Data/Monoid/Average.hs
@@ -39,10 +39,16 @@ import Data.VectorSpace
 -- This average encapsulates length and sum in a space efficient form.
 --
 data Average a = Average { averageWeight :: !Int, averageSum :: !a }
-  deriving (Show, Eq, Ord, Typeable, Functor)
+  deriving (Show, Typeable, Functor)
 
 averageDatum :: a -> Average a
 averageDatum = Average 1
+
+instance (Fractional a, Eq a) => Eq (Average a) where
+  a == b = average a == average b
+
+instance (Fractional a, Ord a) => Ord (Average a) where
+  a `compare` b = average a `compare` average b
 
 instance Num n => Semigroup (Average n) where
   Average lx nx <> Average ly ny = Average (lx + ly) (nx + ny)

--- a/src/Data/Monoid/Average.hs
+++ b/src/Data/Monoid/Average.hs
@@ -37,7 +37,7 @@ import Data.VectorSpace
 --
 -- This average encapsulates length and sum in a space efficient form.
 --
-data Average a = Average !Int a
+data Average a = Average !Int !a
   deriving (Show, Eq, Ord, Typeable, Functor)
 
 averageDatum :: a -> Average a

--- a/src/Data/Monoid/Average.hs
+++ b/src/Data/Monoid/Average.hs
@@ -1,7 +1,6 @@
-
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE TypeFamilies #-}
 
 ------------------------------------------------------------------------------------
 -- |
@@ -25,101 +24,40 @@ module Data.Monoid.Average (
 
 import Prelude hiding ((**))
 
-import Data.Typeable
+import Control.Applicative
+import Control.Monad
+import Data.AdditiveGroup
 import Data.Maybe
 import Data.Semigroup
-import Data.AdditiveGroup
+import Data.Typeable
 import Data.VectorSpace
-import Data.AffineSpace
-import Control.Monad
-import Control.Applicative
 
 -- |
 -- A monoid for 'Average' values.
 --
--- This is actually just the free monoid with an extra function 'average' for
--- extracing the (arithmetic) mean. This function is used to implement 'Real',
--- so you can use 'Average' whenever a ('Monoid', 'Real') is required.
+-- This average encapsulates length and sum in a space efficient form.
 --
--- >>> toRational $ mconcat [1,2::Average Rational]
--- 3 % 2
--- >>> toRational $ mconcat [1,2::Sum Rational]
--- 3 % 1
--- >>> toRational $ mconcat [1,2::Product Rational]
--- 2 % 1
---
-newtype Average a = Average { getAverage :: [a] }
-  deriving (Show, Semigroup, Monoid, Typeable, Functor, Applicative)
+data Average a = Average !Int a
+  deriving (Show, Eq, Ord, Typeable, Functor)
 
-instance (Fractional a, Eq a) => Eq (Average a) where
-  a == b = average a == average b
+averageDatum :: a -> Average a
+averageDatum = Average 1
 
-instance (Fractional a, Ord a) => Ord (Average a) where
-  a `compare` b = average a `compare` average b
-  
--- What should (+) and (*) do for Average values?
--- 
--- The important thing is to preserve scalar addition and multiplication (for example
--- scaling all components of) an average value by some constant factor, so we can just as
--- well use the standard list instance. What about averages with more components? I *think*
--- 'average' is a linear map, so they would work as expected:
--- 
--- >>> average (2<>2<>3)+average (3<>3)
--- 16 % 3
--- >>> average $ (2<>2<>3)+(3<>3)
--- 16 % 3
--- >>> average (mconcat [5,6,9])*average (mconcat[-1,0])
--- (-10) % 3
--- >>> average $ (mconcat [5,6,9])*(mconcat[-1,0])
--- (-10) % 3
--- 
+instance Num n => Semigroup (Average n) where
+  Average lx nx <> Average ly ny = Average (lx + ly) (nx + ny)
 
-instance Num a => Num (Average a) where
-  (+) = liftA2 (+)
-  (*) = liftA2 (*)
-  negate = fmap negate
-  abs    = fmap abs
-  signum = fmap signum
-  fromInteger = pure . fromInteger
-  
-instance (Fractional a, Num a) => Fractional (Average a) where
-  (/) = liftA2 (/)
-  fromRational = pure . fromRational
+instance Num n => Monoid (Average n) where
+  mappend = (<>)
+  mempty = Average 0 0
 
-instance (Real a, Fractional a) => Real (Average a) where
-  toRational = toRational . average
-
-instance Floating a => Floating (Average a) where
-  pi = pure pi
-  exp = fmap exp
-  sqrt = fmap sqrt
-  log = fmap log
-  sin = fmap sin
-  tan = fmap tan
-  cos = fmap cos
-  asin = fmap asin
-  atan = fmap atan
-  acos = fmap acos
-  sinh = fmap sinh
-  tanh = fmap tanh
-  cosh = fmap cosh
-  asinh = fmap asinh
-  atanh = fmap atanh
-  acosh = fmap acosh
-  
 instance AdditiveGroup a => AdditiveGroup (Average a) where
-  zeroV = pure zeroV
-  (^+^) = liftA2 (^+^)
+  zeroV = Average 0 zeroV
+  Average xl xn ^+^ Average yl yn = Average (xl + yl) (xn ^+^ yn)
   negateV = fmap negateV
 
 instance VectorSpace a => VectorSpace (Average a) where
   type Scalar (Average a) = Scalar a
-  s *^ v = liftA2 (*^) (pure s) v
-
-instance AffineSpace a => AffineSpace (Average a) where
-  type Diff (Average a) = Average (Diff a)
-  p1 .-. p2 = liftA2 (.-.) p1 p2
-  p .+^ v   = liftA2 (.+^) p v
+  s *^ avg  = fmap (s *^) avg
 
 {-
 instance Arbitrary a => Arbitrary (Average a) where
@@ -132,7 +70,5 @@ average = fromMaybe 0 . maybeAverage
 
 -- | Return the average of all monoidal components. If given 'mempty', return 'Nothing'.
 maybeAverage :: Fractional a => Average a -> Maybe a
-maybeAverage (Average []) = Nothing
-maybeAverage (Average xs) = Just $ sum xs / fromIntegral (length xs)
-
-
+maybeAverage (Average 0 _) = Nothing
+maybeAverage (Average l x) = Just $ x / fromIntegral l

--- a/src/Data/Monoid/Average.hs
+++ b/src/Data/Monoid/Average.hs
@@ -19,8 +19,8 @@
 module Data.Monoid.Average (
     Average(..),
     averageDatum,
-    average,
-    maybeAverage
+    getAverage,
+    mayAverage
   ) where
 
 import Prelude hiding ((**))
@@ -38,7 +38,7 @@ import Data.VectorSpace
 --
 -- This average encapsulates length and sum in a space efficient form.
 --
--- >>> average $ foldMap averageDatum [1,2,3]
+-- >>> getAverage $ foldMap averageDatum [1,2,3]
 -- 2.0
 --
 data Average a = Average { averageWeight :: !Int, averageSum :: !a }
@@ -48,10 +48,10 @@ averageDatum :: a -> Average a
 averageDatum = Average 1
 
 instance (Fractional a, Eq a) => Eq (Average a) where
-  a == b = average a == average b
+  a == b = getAverage a == getAverage b
 
 instance (Fractional a, Ord a) => Ord (Average a) where
-  a `compare` b = average a `compare` average b
+  a `compare` b = getAverage a `compare` getAverage b
 
 instance Num n => Semigroup (Average n) where
   Average lx nx <> Average ly ny = Average (lx + ly) (nx + ny)
@@ -75,10 +75,10 @@ instance Arbitrary a => Arbitrary (Average a) where
 -}
 
 -- | Return the average of all monoidal components. If given 'mempty', return zero.
-average :: Fractional a => Average a -> a
-average = fromMaybe 0 . maybeAverage
+getAverage :: Fractional a => Average a -> a
+getAverage = fromMaybe 0 . mayAverage
 
 -- | Return the average of all monoidal components. If given 'mempty', return 'Nothing'.
-maybeAverage :: Fractional a => Average a -> Maybe a
-maybeAverage (Average 0 _) = Nothing
-maybeAverage (Average l x) = Just $ x / fromIntegral l
+mayAverage :: Fractional a => Average a -> Maybe a
+mayAverage (Average 0 _) = Nothing
+mayAverage (Average l x) = Just $ x / fromIntegral l

--- a/src/Data/Monoid/Average.hs
+++ b/src/Data/Monoid/Average.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE TypeFamilies #-}
 
 ------------------------------------------------------------------------------------
 -- |

--- a/src/Data/Monoid/Average.hs
+++ b/src/Data/Monoid/Average.hs
@@ -26,7 +26,6 @@ import Prelude hiding ((**))
 
 import Control.Applicative
 import Control.Monad
-import Data.AdditiveGroup
 import Data.Function (on)
 import Data.Maybe
 import Data.Semigroup
@@ -58,11 +57,6 @@ instance Num n => Semigroup (Average n) where
 instance Num n => Monoid (Average n) where
   mappend = (<>)
   mempty = Average 0 0
-
-instance AdditiveGroup a => AdditiveGroup (Average a) where
-  zeroV = Average 0 zeroV
-  x ^+^ y = Average (on (+) averageWeight x y) (on (^+^) averageSum x y)
-  negateV = fmap negateV
 
 -- | Return the average of all monoidal components. If given 'mempty', return zero.
 getAverage :: Fractional a => Average a -> a

--- a/src/Data/Monoid/Average.hs
+++ b/src/Data/Monoid/Average.hs
@@ -18,7 +18,8 @@
 module Data.Monoid.Average (
     Average(..),
     getAverage,
-    mayAverage
+    mayAverage,
+    averageDatum
   ) where
 
 import Prelude hiding ((**))
@@ -41,6 +42,9 @@ import Data.Typeable
 --
 data Average a = Average { averageWeight :: !Int, averageSum :: !a }
   deriving (Show, Typeable, Functor)
+
+averageDatum :: n -> Average n
+averageDatum = Average 1
 
 instance (Fractional a, Eq a) => Eq (Average a) where
   a == b = getAverage a == getAverage b

--- a/src/Data/Monoid/Average.hs
+++ b/src/Data/Monoid/Average.hs
@@ -18,7 +18,6 @@
 
 module Data.Monoid.Average (
     Average(..),
-    averageDatum,
     getAverage,
     mayAverage
   ) where
@@ -44,14 +43,48 @@ import Data.VectorSpace
 data Average a = Average { averageWeight :: !Int, averageSum :: !a }
   deriving (Show, Typeable, Functor)
 
-averageDatum :: a -> Average a
-averageDatum = Average 1
-
 instance (Fractional a, Eq a) => Eq (Average a) where
   a == b = getAverage a == getAverage b
 
 instance (Fractional a, Ord a) => Ord (Average a) where
   a `compare` b = getAverage a `compare` getAverage b
+
+instance Applicative Average where
+  pure = Average 1
+  Average wf f <*> Average wx x = Average (wf + wx) $ f x
+
+instance Num a => Num (Average a) where
+  (+) = liftA2 (+)
+  (*) = liftA2 (*)
+  negate = fmap negate
+  abs    = fmap abs
+  signum = fmap signum
+  fromInteger = pure . fromInteger
+
+instance (Fractional a, Num a) => Fractional (Average a) where
+  (/) = liftA2 (/)
+  fromRational = pure . fromRational
+
+instance (Real a, Fractional a) => Real (Average a) where
+  toRational = toRational . getAverage
+
+instance Floating a => Floating (Average a) where
+  pi = pure pi
+  exp = fmap exp
+  sqrt = fmap sqrt
+  log = fmap log
+  sin = fmap sin
+  tan = fmap tan
+  cos = fmap cos
+  asin = fmap asin
+  atan = fmap atan
+  acos = fmap acos
+  sinh = fmap sinh
+  tanh = fmap tanh
+  cosh = fmap cosh
+  asinh = fmap asinh
+  atanh = fmap atanh
+  acosh = fmap acosh
 
 instance Num n => Semigroup (Average n) where
   Average lx nx <> Average ly ny = Average (lx + ly) (nx + ny)
@@ -62,12 +95,13 @@ instance Num n => Monoid (Average n) where
 
 instance AdditiveGroup a => AdditiveGroup (Average a) where
   zeroV = Average 0 zeroV
-  Average xl xn ^+^ Average yl yn = Average (xl + yl) (xn ^+^ yn)
+  (^+^) = liftA2 (^+^)
   negateV = fmap negateV
 
 instance VectorSpace a => VectorSpace (Average a) where
   type Scalar (Average a) = Scalar a
   s *^ avg  = fmap (s *^) avg
+
 
 {-
 instance Arbitrary a => Arbitrary (Average a) where

--- a/src/Data/Monoid/Average.hs
+++ b/src/Data/Monoid/Average.hs
@@ -18,6 +18,7 @@
 
 module Data.Monoid.Average (
     Average(..),
+    averageDatum,
     average,
     maybeAverage
   ) where
@@ -37,7 +38,7 @@ import Data.VectorSpace
 --
 -- This average encapsulates length and sum in a space efficient form.
 --
-data Average a = Average !Int !a
+data Average a = Average { averageWeight :: !Int, averageSum :: !a }
   deriving (Show, Eq, Ord, Typeable, Functor)
 
 averageDatum :: a -> Average a

--- a/src/Data/Monoid/Average.hs
+++ b/src/Data/Monoid/Average.hs
@@ -38,6 +38,9 @@ import Data.VectorSpace
 --
 -- This average encapsulates length and sum in a space efficient form.
 --
+-- >>> average $ foldMap averageDatum [1,2,3]
+-- 2.0
+--
 data Average a = Average { averageWeight :: !Int, averageSum :: !a }
   deriving (Show, Typeable, Functor)
 

--- a/src/Data/Monoid/Average.hs
+++ b/src/Data/Monoid/Average.hs
@@ -27,10 +27,10 @@ import Prelude hiding ((**))
 import Control.Applicative
 import Control.Monad
 import Data.AdditiveGroup
+import Data.Function (on)
 import Data.Maybe
 import Data.Semigroup
 import Data.Typeable
-import Data.VectorSpace
 
 -- |
 -- A monoid for 'Average' values.
@@ -49,43 +49,6 @@ instance (Fractional a, Eq a) => Eq (Average a) where
 instance (Fractional a, Ord a) => Ord (Average a) where
   a `compare` b = getAverage a `compare` getAverage b
 
-instance Applicative Average where
-  pure = Average 1
-  Average wf f <*> Average wx x = Average (wf + wx) $ f x
-
-instance Num a => Num (Average a) where
-  (+) = liftA2 (+)
-  (*) = liftA2 (*)
-  negate = fmap negate
-  abs    = fmap abs
-  signum = fmap signum
-  fromInteger = pure . fromInteger
-
-instance (Fractional a, Num a) => Fractional (Average a) where
-  (/) = liftA2 (/)
-  fromRational = pure . fromRational
-
-instance (Real a, Fractional a) => Real (Average a) where
-  toRational = toRational . getAverage
-
-instance Floating a => Floating (Average a) where
-  pi = pure pi
-  exp = fmap exp
-  sqrt = fmap sqrt
-  log = fmap log
-  sin = fmap sin
-  tan = fmap tan
-  cos = fmap cos
-  asin = fmap asin
-  atan = fmap atan
-  acos = fmap acos
-  sinh = fmap sinh
-  tanh = fmap tanh
-  cosh = fmap cosh
-  asinh = fmap asinh
-  atanh = fmap atanh
-  acosh = fmap acosh
-
 instance Num n => Semigroup (Average n) where
   Average lx nx <> Average ly ny = Average (lx + ly) (nx + ny)
 
@@ -95,18 +58,8 @@ instance Num n => Monoid (Average n) where
 
 instance AdditiveGroup a => AdditiveGroup (Average a) where
   zeroV = Average 0 zeroV
-  (^+^) = liftA2 (^+^)
+  x ^+^ y = Average (on (+) averageWeight x y) (on (^+^) averageSum x y)
   negateV = fmap negateV
-
-instance VectorSpace a => VectorSpace (Average a) where
-  type Scalar (Average a) = Scalar a
-  s *^ avg  = fmap (s *^) avg
-
-
-{-
-instance Arbitrary a => Arbitrary (Average a) where
-  arbitrary = fmap Average arbitrary
--}
 
 -- | Return the average of all monoidal components. If given 'mempty', return zero.
 getAverage :: Fractional a => Average a -> a

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -6,12 +6,11 @@ module Main (main) where
 
 import Data.AdditiveGroup
 import Data.Monoid.Average
-import Data.VectorSpace
 import Test.Hspec
 import Test.Hspec.Checkers
 import Test.QuickCheck
 import Test.QuickCheck.Checkers
-import Test.QuickCheck.Classes (applicative, functor, monoid)
+import Test.QuickCheck.Classes (functor, monoid)
 
 
 instance Arbitrary (Average Int) where
@@ -34,3 +33,5 @@ main =
         it "commutative" . property $ isCommut @(Average Int) (^+^)
         it "left identity" . property $ leftId @(Average Int) (^+^) zeroV
         it "right identity" . property $ rightId @(Average Int) (^+^) zeroV
+        it "left inverse" . property $ \(a :: Average Int) -> (negateV a) ^+^ a =-= zeroV
+        it "right inverse" . property $ \(a :: Average Int) -> a ^+^ (negateV a) =-= zeroV

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -25,6 +25,17 @@ main =
   hspec $
     describe "Average" $ do
       testBatch $ monoid (undefined :: Average Int)
+      describe "laws for: Num" $ do
+        describe "addition" $ do
+          it "associativity" . property $ isAssoc @(Average Int) (+)
+          it "commutative" . property $ isCommut @(Average Int) (+)
+          it "left identity" . property $ leftId @(Average Int) (+) 0
+          it "right identity" . property $ rightId @(Average Int) (+) 0
+        describe "multiplication" $ do
+          it "associativity" . property $ isAssoc @(Average Int) (*)
+          it "commutative" . property $ isCommut @(Average Int) (*)
+          it "left identity" . property $ leftId @(Average Int) (*) 1
+          it "right identity" . property $ rightId @(Average Int) (*) 1
       describe "laws for: vector space" $ do
         it "associativity" . property $ isAssoc @(Average Int) (^+^)
         it "commutative" . property $ isCommut @(Average Int) (^+^)

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -29,29 +29,8 @@ main =
     describe "Average" $ do
       testBatch $ monoid (undefined :: Average Int)
       testBatch $ functor (undefined :: Average (Int, Int, Int))
-      testBatch $ applicative (undefined :: Average (Int, Int, Int))
-      describe "laws for: Num" $ do
-        describe "addition" $ do
-          it "associativity" . property $ isAssoc @(Average Int) (+)
-          it "commutative" . property $ isCommut @(Average Int) (+)
-          it "left identity" . property $ leftId @(Average Int) (+) 0
-          it "right identity" . property $ rightId @(Average Int) (+) 0
-        describe "multiplication" $ do
-          it "associativity" . property $ isAssoc @(Average Int) (*)
-          it "commutative" . property $ isCommut @(Average Int) (*)
-          it "left identity" . property $ leftId @(Average Int) (*) 1
-          it "right identity" . property $ rightId @(Average Int) (*) 1
-      describe "laws for: vector space" $ do
+      describe "laws for: additive group" $ do
         it "associativity" . property $ isAssoc @(Average Int) (^+^)
         it "commutative" . property $ isCommut @(Average Int) (^+^)
         it "left identity" . property $ leftId @(Average Int) (^+^) zeroV
         it "right identity" . property $ rightId @(Average Int) (^+^) zeroV
-        describe "closure" $ do
-          it "distributive: c u v" . property $ \(c, u, v :: Average Int) ->
-            c *^ (u ^+^ v) =-= (c *^ u) ^+^ (c *^ v)
-          it "distributive: c d v" . property $ \(c, d, v :: Average Int) ->
-            (c ^+^ d) *^ v =-= c *^ v ^+^ d *^ v
-          it "associativity" . property $ \(c, d, v :: Average Int) ->
-            c *^ (d *^ v) =-= (c * d) *^ v
-          it "unitary" . property $ \(v :: Average Int) ->
-            1 *^ v =-= v

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Main (main) where
+
+import Data.AdditiveGroup
+import Data.Monoid.Average
+import Data.VectorSpace
+import Test.Hspec
+import Test.Hspec.Checkers
+import Test.QuickCheck
+import Test.QuickCheck.Checkers
+import Test.QuickCheck.Classes (monoid)
+
+
+instance Arbitrary (Average Int) where
+  arbitrary = Average <$> (getPositive <$> arbitrary) <*> arbitrary
+
+instance EqProp (Average Int) where
+  x =-= y = getAverage (fmap fromIntegral x :: Average Double) =-= getAverage (fmap fromIntegral y)
+
+main :: IO ()
+main =
+  hspec $
+    describe "Average" $ do
+      testBatch $ monoid (undefined :: Average Int)
+      describe "laws for: vector space" $ do
+        it "associativity" . property $ isAssoc @(Average Int) (^+^)
+        it "commutative" . property $ isCommut @(Average Int) (^+^)
+        it "left identity" . property $ leftId @(Average Int) (^+^) zeroV
+        it "right identity" . property $ rightId @(Average Int) (^+^) zeroV
+        describe "closure" $ do
+          it "distributive: c u v" . property $ \(c, u, v :: Average Int) ->
+            c *^ (u ^+^ v) =-= (c *^ u) ^+^ (c *^ v)
+          it "distributive: c d v" . property $ \(c, d, v :: Average Int) ->
+            (c ^+^ d) *^ v =-= c *^ v ^+^ d *^ v
+          it "associativity" . property $ \(c, d, v :: Average Int) ->
+            c *^ (d *^ v) =-= (c * d) *^ v
+          it "unitary" . property $ \(v :: Average Int) ->
+            1 *^ v =-= v

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -11,10 +11,13 @@ import Test.Hspec
 import Test.Hspec.Checkers
 import Test.QuickCheck
 import Test.QuickCheck.Checkers
-import Test.QuickCheck.Classes (monoid)
+import Test.QuickCheck.Classes (applicative, functor, monoid)
 
 
 instance Arbitrary (Average Int) where
+  arbitrary = Average <$> (getPositive <$> arbitrary) <*> arbitrary
+
+instance Arbitrary (Average (Int -> Int)) where
   arbitrary = Average <$> (getPositive <$> arbitrary) <*> arbitrary
 
 instance EqProp (Average Int) where
@@ -25,6 +28,8 @@ main =
   hspec $
     describe "Average" $ do
       testBatch $ monoid (undefined :: Average Int)
+      testBatch $ functor (undefined :: Average (Int, Int, Int))
+      testBatch $ applicative (undefined :: Average (Int, Int, Int))
       describe "laws for: Num" $ do
         describe "addition" $ do
           it "associativity" . property $ isAssoc @(Average Int) (+)

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -4,7 +4,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Main (main) where
 
-import Data.AdditiveGroup
 import Data.Monoid.Average
 import Test.Hspec
 import Test.Hspec.Checkers
@@ -28,10 +27,3 @@ main =
     describe "Average" $ do
       testBatch $ monoid (undefined :: Average Int)
       testBatch $ functor (undefined :: Average (Int, Int, Int))
-      describe "laws for: additive group" $ do
-        it "associativity" . property $ isAssoc @(Average Int) (^+^)
-        it "commutative" . property $ isCommut @(Average Int) (^+^)
-        it "left identity" . property $ leftId @(Average Int) (^+^) zeroV
-        it "right identity" . property $ rightId @(Average Int) (^+^) zeroV
-        it "left inverse" . property $ \(a :: Average Int) -> (negateV a) ^+^ a =-= zeroV
-        it "right inverse" . property $ \(a :: Average Int) -> a ^+^ (negateV a) =-= zeroV


### PR DESCRIPTION
The list based monoid representation is not space efficient. This
implementation also leads towards a number of confusing and highly
opinionated instances. This new implementation is space efficient, ideal
for on-line algorithms and does not include possibly confusing/problematic
instances.

This addresses feedback in https://github.com/hanshoglund/average/issues/3

This may seem like an aggressive PR. I recognize that. However I believe
this package name is too high value for it to be populated by an inefficient
implementation.