### PR TITLE
Refactor: store only a weight and running sum

### DIFF
--- a/average.cabal
+++ b/average.cabal
@@ -36,7 +36,7 @@ test-suite spec
     ghc-options: -Wall -rtsopts -O0
     build-depends:
         average,
-        base            >= 4 && < 5,
+        base            >= 4.9 && < 5,
         vector-space    >= 0.8.7 && < 0.11,
         semigroups      >= 0.13.0.1 && < 1,
         QuickCheck      >= 2 && < 3,

--- a/average.cabal
+++ b/average.cabal
@@ -22,7 +22,8 @@ library
     build-depends:
         base            >= 4 && < 5,
         vector-space    >= 0.8.7 && < 0.11,
-        semigroups      >= 0.13.0.1 && < 1
+        semigroups      >= 0.13.0.1 && < 1,
+        mono-traversable >= 1.0 && < 1.1
     hs-source-dirs:     src
     default-language:   Haskell2010
     exposed-modules:

--- a/average.cabal
+++ b/average.cabal
@@ -28,3 +28,18 @@ library
     exposed-modules:
         Data.Monoid.Average
 
+test-suite spec
+    type: exitcode-stdio-1.0
+    main-is: Spec.hs
+    hs-source-dirs:
+          tests
+    ghc-options: -Wall -rtsopts -O0
+    build-depends:
+        average,
+        base            >= 4 && < 5,
+        vector-space    >= 0.8.7 && < 0.11,
+        semigroups      >= 0.13.0.1 && < 1,
+        QuickCheck      >= 2 && < 3,
+        hspec           >= 2.4 && < 2.5,
+        hspec-checkers  >= 0.1 && < 0.2,
+        checkers        >= 0.4 && < 0.5

--- a/src/Data/Monoid/Average.hs
+++ b/src/Data/Monoid/Average.hs
@@ -1,7 +1,9 @@
 
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveFunctor #-}
 
 ------------------------------------------------------------------------------------
 -- |
@@ -19,107 +21,110 @@
 
 module Data.Monoid.Average (
     Average(..),
-    average,
-    maybeAverage
+    getAverage,
+    mayAverage
   ) where
 
 import Prelude hiding ((**))
 
 import Data.Typeable
 import Data.Maybe
+import Data.Function (on)
 import Data.Semigroup
 import Data.AdditiveGroup
 import Data.VectorSpace
 import Data.AffineSpace
 import Control.Monad
 import Control.Applicative
+import Data.MonoTraversable
 
 -- |
 -- A monoid for 'Average' values.
 --
--- This is actually just the free monoid with an extra function 'average' for
--- extracing the (arithmetic) mean. This function is used to implement 'Real',
--- so you can use 'Average' whenever a ('Monoid', 'Real') is required.
+-- Represented by a running sum and a weight (i.e. a count of how many elements
+-- have been summed, which allows calculating the average).
 --
--- >>> toRational $ mconcat [1,2::Average Rational]
--- 3 % 2
--- >>> toRational $ mconcat [1,2::Sum Rational]
--- 3 % 1
--- >>> toRational $ mconcat [1,2::Product Rational]
--- 2 % 1
+-- >>> getAverage $ foldMap averageDatum [1,2,3]
+-- 2.0
 --
-newtype Average a = Average { getAverage :: [a] }
-  deriving (Show, Semigroup, Monoid, Typeable, Functor, Applicative)
+data Average a = Average { averageWeight :: !Int, runningSum :: !a }
+  deriving (Show, Typeable)
 
-instance (Fractional a, Eq a) => Eq (Average a) where
-  a == b = average a == average b
+type instance Element (Average a) = a
+instance (VectorSpace v, Fractional (Scalar v)) => MonoFunctor (Average v) where
+  omap f (Average w a) = Average w $ w' *^ f (a ^/ w')
+   where w' = fromIntegral w
 
-instance (Fractional a, Ord a) => Ord (Average a) where
-  a `compare` b = average a `compare` average b
+instance MonoPointed (Average v) where
+  opoint = Average 1
   
--- What should (+) and (*) do for Average values?
--- 
--- The important thing is to preserve scalar addition and multiplication (for example
--- scaling all components of) an average value by some constant factor, so we can just as
--- well use the standard list instance. What about averages with more components? I *think*
--- 'average' is a linear map, so they would work as expected:
--- 
--- >>> average (2<>2<>3)+average (3<>3)
--- 16 % 3
--- >>> average $ (2<>2<>3)+(3<>3)
--- 16 % 3
--- >>> average (mconcat [5,6,9])*average (mconcat[-1,0])
--- (-10) % 3
--- >>> average $ (mconcat [5,6,9])*(mconcat[-1,0])
--- (-10) % 3
--- 
+avgLiftA2 :: (VectorSpace v, Fractional (Scalar v))
+             => (v -> v -> v) -> Average v -> Average v -> Average v
+avgLiftA2 f (Average wx xΣ) (Average wy yΣ)
+    = Average wΠ $ (f (xΣ^/fromIntegral wx) (yΣ^/fromIntegral wy))
+                     ^* fromIntegral wΠ
+ where wΠ = wx*wy
 
-instance Num a => Num (Average a) where
-  (+) = liftA2 (+)
-  (*) = liftA2 (*)
-  negate = fmap negate
-  abs    = fmap abs
-  signum = fmap signum
-  fromInteger = pure . fromInteger
+instance (VectorSpace v, Fractional (Scalar v)) => Semigroup (Average v) where
+  a <> b = Average (on (+) averageWeight a b) (on (^+^) runningSum a b)
+
+instance (VectorSpace v, Fractional (Scalar v)) => Monoid (Average v) where
+  mempty = Average 0 zeroV
+  mappend = (<>)
+    
+instance (VectorSpace v, Fractional (Scalar v), Eq v) => Eq (Average v) where
+  a == b = getAverage a == getAverage b
+
+instance (VectorSpace v, Fractional (Scalar v), Ord v) => Ord (Average v) where
+  a `compare` b = getAverage a `compare` getAverage b
+
+instance (Fractional a, VectorSpace a, Scalar a ~ a) => Num (Average a) where
+  (+) = avgLiftA2 (+)
+  (*) = avgLiftA2 (*)
+  negate = omap negate
+  abs    = omap abs
+  signum = omap signum
+  fromInteger = opoint . fromInteger
   
-instance (Fractional a, Num a) => Fractional (Average a) where
-  (/) = liftA2 (/)
-  fromRational = pure . fromRational
+instance (Fractional a, VectorSpace a, Scalar a ~ a) => Fractional (Average a) where
+  (/) = avgLiftA2 (/)
+  fromRational = opoint . fromRational
 
-instance (Real a, Fractional a) => Real (Average a) where
-  toRational = toRational . average
+instance (RealFrac a, VectorSpace a, Scalar a ~ a) => Real (Average a) where
+  toRational = toRational . getAverage
 
-instance Floating a => Floating (Average a) where
-  pi = pure pi
-  exp = fmap exp
-  sqrt = fmap sqrt
-  log = fmap log
-  sin = fmap sin
-  tan = fmap tan
-  cos = fmap cos
-  asin = fmap asin
-  atan = fmap atan
-  acos = fmap acos
-  sinh = fmap sinh
-  tanh = fmap tanh
-  cosh = fmap cosh
-  asinh = fmap asinh
-  atanh = fmap atanh
-  acosh = fmap acosh
+instance (Floating a, VectorSpace a, Scalar a ~ a) => Floating (Average a) where
+  pi = opoint pi
+  exp = omap exp
+  sqrt = omap sqrt
+  log = omap log
+  sin = omap sin
+  tan = omap tan
+  cos = omap cos
+  asin = omap asin
+  atan = omap atan
+  acos = omap acos
+  sinh = omap sinh
+  tanh = omap tanh
+  cosh = omap cosh
+  asinh = omap asinh
+  atanh = omap atanh
+  acosh = omap acosh
   
-instance AdditiveGroup a => AdditiveGroup (Average a) where
-  zeroV = pure zeroV
-  (^+^) = liftA2 (^+^)
-  negateV = fmap negateV
+instance (VectorSpace a, Fractional (Scalar a)) => AdditiveGroup (Average a) where
+  zeroV = opoint zeroV
+  (^+^) = avgLiftA2 (^+^)
+  negateV = omap negateV
 
-instance VectorSpace a => VectorSpace (Average a) where
+instance (VectorSpace a, Fractional (Scalar a)) => VectorSpace (Average a) where
   type Scalar (Average a) = Scalar a
-  s *^ v = liftA2 (*^) (pure s) v
+  s *^ Average w v = Average w $ s*^v
 
-instance AffineSpace a => AffineSpace (Average a) where
+instance (AffineSpace a, VectorSpace a, Diff a ~ a, Fractional (Scalar a))
+                => AffineSpace (Average a) where
   type Diff (Average a) = Average (Diff a)
-  p1 .-. p2 = liftA2 (.-.) p1 p2
-  p .+^ v   = liftA2 (.+^) p v
+  (.-.) = (^-^)
+  (.+^) = (^+^)
 
 {-
 instance Arbitrary a => Arbitrary (Average a) where
@@ -127,12 +132,10 @@ instance Arbitrary a => Arbitrary (Average a) where
 -}
 
 -- | Return the average of all monoidal components. If given 'mempty', return zero.
-average :: Fractional a => Average a -> a
-average = fromMaybe 0 . maybeAverage
+getAverage :: (VectorSpace v, Fractional (Scalar v)) => Average v -> v
+getAverage = maybe zeroV id . mayAverage
 
 -- | Return the average of all monoidal components. If given 'mempty', return 'Nothing'.
-maybeAverage :: Fractional a => Average a -> Maybe a
-maybeAverage (Average []) = Nothing
-maybeAverage (Average xs) = Just $ sum xs / fromIntegral (length xs)
-
-
+mayAverage :: (VectorSpace v, Fractional (Scalar v)) => Average v -> Maybe v
+mayAverage (Average 0 _) = Nothing
+mayAverage (Average l x) = Just $ x ^/ fromIntegral l

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -11,25 +11,23 @@ import Test.Hspec
 import Test.Hspec.Checkers
 import Test.QuickCheck
 import Test.QuickCheck.Checkers
-import Test.QuickCheck.Classes (applicative, functor, monoid)
+import Test.QuickCheck.Classes (monoid)
 
 
 instance Arbitrary (Average Rational) where
-  arbitrary = Average <$> arbitrary
+  arbitrary = Average <$> (getPositive <$> arbitrary) <*> arbitrary
 
 instance Arbitrary (Average (Rational -> Rational)) where
-  arbitrary = Average <$> arbitrary
+  arbitrary = Average <$> (getPositive <$> arbitrary) <*> arbitrary
 
 instance EqProp (Average Rational) where
-  Average l =-= Average m = (l==m) =-= True
+  Average wx xΣ =-= Average wy yΣ = (wx==wy, xΣ==yΣ) =-= (True, True)
 
 main :: IO ()
 main =
   hspec $
     describe "Average" $ do
       testBatch $ monoid (undefined :: Average Rational)
-      testBatch $ functor (undefined :: Average (Rational, Rational, Rational))
-      testBatch $ applicative (undefined :: Average (Rational, Rational, Rational))
       describe "laws for: Num" $ do
         describe "addition" $ do
           it "associativity" . property $ isAssoc @(Average Rational) (+)

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -25,6 +25,17 @@ main =
   hspec $
     describe "Average" $ do
       testBatch $ monoid (undefined :: Average Int)
+      describe "laws for: Num" $ do
+        describe "addition" $ do
+          it "associativity" . property $ isAssoc @(Average Int) (+)
+          it "commutative" . property $ isCommut @(Average Int) (+)
+          it "left identity" . property $ leftId @(Average Int) (+) 0
+          it "right identity" . property $ rightId @(Average Int) (+) 0
+        describe "multiplication" $ do
+          it "associativity" . property $ isAssoc @(Average Int) (*)
+          it "commutative" . property $ isCommut @(Average Int) (*)
+          it "left identity" . property $ leftId @(Average Int) (*) 1
+          it "right identity" . property $ rightId @(Average Int) (*) 1
       describe "laws for: vector space" $ do
         it "associativity" . property $ isAssoc @(Average Int) (^+^)
         it "commutative" . property $ isCommut @(Average Int) (^+^)

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Main (main) where
+
+import Data.AdditiveGroup
+import Data.Monoid.Average
+import Data.VectorSpace
+import Test.Hspec
+import Test.Hspec.Checkers
+import Test.QuickCheck
+import Test.QuickCheck.Checkers
+import Test.QuickCheck.Classes (monoid)
+
+
+instance Arbitrary (Average Int) where
+  arbitrary = Average <$> arbitrary
+
+instance EqProp (Average Int) where
+  x =-= y = getAverage (fmap fromIntegral x :: Average Double) =-= getAverage (fmap fromIntegral y)
+
+main :: IO ()
+main =
+  hspec $
+    describe "Average" $ do
+      testBatch $ monoid (undefined :: Average Int)
+      describe "laws for: vector space" $ do
+        it "associativity" . property $ isAssoc @(Average Int) (^+^)
+        it "commutative" . property $ isCommut @(Average Int) (^+^)
+        it "left identity" . property $ leftId @(Average Int) (^+^) zeroV
+        it "right identity" . property $ rightId @(Average Int) (^+^) zeroV
+        describe "closure" $ do
+          it "distributive: c u v" . property $ \(c, u, v :: Average Int) ->
+            c *^ (u ^+^ v) =-= (c *^ u) ^+^ (c *^ v)
+          it "distributive: c d v" . property $ \(c, d, v :: Average Int) ->
+            (c ^+^ d) *^ v =-= c *^ v ^+^ d *^ v
+          it "associativity" . property $ \(c, d, v :: Average Int) ->
+            c *^ (d *^ v) =-= (c * d) *^ v
+          it "unitary" . property $ \(v :: Average Int) ->
+            1 *^ v =-= v

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -46,6 +46,8 @@ main =
         it "commutative" . property $ isCommut @(Average Rational) (^+^)
         it "left identity" . property $ leftId @(Average Rational) (^+^) zeroV
         it "right identity" . property $ rightId @(Average Rational) (^+^) zeroV
+        it "left inverse" . property $ \(a :: Average Rational) -> negateV a ^+^ a =-= zeroV
+        it "right inverse" . property $ \(a :: Average Rational) -> a ^+^ negateV a =-= zeroV
         describe "closure" $ do
           it "distributive: c u v" . property $ \(c, u, v :: Average Rational) ->
             c *^ (u ^+^ v) =-= (c *^ u) ^+^ (c *^ v)

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -21,9 +21,7 @@ instance Arbitrary (Average (Rational -> Rational)) where
   arbitrary = Average <$> arbitrary
 
 instance EqProp (Average Rational) where
-  x =-= y
-     = (getAverage x==getAverage y) =-= True
-          -- for some reason, checkers <0.5 doesn't support `Rational` or even `Integer`.
+  Average l =-= Average m = (l==m) =-= True
 
 main :: IO ()
 main =

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -11,10 +11,13 @@ import Test.Hspec
 import Test.Hspec.Checkers
 import Test.QuickCheck
 import Test.QuickCheck.Checkers
-import Test.QuickCheck.Classes (monoid)
+import Test.QuickCheck.Classes (applicative, functor, monoid)
 
 
 instance Arbitrary (Average Int) where
+  arbitrary = Average <$> arbitrary
+
+instance Arbitrary (Average (Int -> Int)) where
   arbitrary = Average <$> arbitrary
 
 instance EqProp (Average Int) where
@@ -25,6 +28,8 @@ main =
   hspec $
     describe "Average" $ do
       testBatch $ monoid (undefined :: Average Int)
+      testBatch $ functor (undefined :: Average (Int, Int, Int))
+      testBatch $ applicative (undefined :: Average (Int, Int, Int))
       describe "laws for: Num" $ do
         describe "addition" $ do
           it "associativity" . property $ isAssoc @(Average Int) (+)

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -14,44 +14,46 @@ import Test.QuickCheck.Checkers
 import Test.QuickCheck.Classes (applicative, functor, monoid)
 
 
-instance Arbitrary (Average Int) where
+instance Arbitrary (Average Rational) where
   arbitrary = Average <$> arbitrary
 
-instance Arbitrary (Average (Int -> Int)) where
+instance Arbitrary (Average (Rational -> Rational)) where
   arbitrary = Average <$> arbitrary
 
-instance EqProp (Average Int) where
-  x =-= y = getAverage (fmap fromIntegral x :: Average Double) =-= getAverage (fmap fromIntegral y)
+instance EqProp (Average Rational) where
+  x =-= y
+     = (getAverage x==getAverage y) =-= True
+          -- for some reason, checkers <0.5 doesn't support `Rational` or even `Integer`.
 
 main :: IO ()
 main =
   hspec $
     describe "Average" $ do
-      testBatch $ monoid (undefined :: Average Int)
-      testBatch $ functor (undefined :: Average (Int, Int, Int))
-      testBatch $ applicative (undefined :: Average (Int, Int, Int))
+      testBatch $ monoid (undefined :: Average Rational)
+      testBatch $ functor (undefined :: Average (Rational, Rational, Rational))
+      testBatch $ applicative (undefined :: Average (Rational, Rational, Rational))
       describe "laws for: Num" $ do
         describe "addition" $ do
-          it "associativity" . property $ isAssoc @(Average Int) (+)
-          it "commutative" . property $ isCommut @(Average Int) (+)
-          it "left identity" . property $ leftId @(Average Int) (+) 0
-          it "right identity" . property $ rightId @(Average Int) (+) 0
+          it "associativity" . property $ isAssoc @(Average Rational) (+)
+          it "commutative" . property $ isCommut @(Average Rational) (+)
+          it "left identity" . property $ leftId @(Average Rational) (+) 0
+          it "right identity" . property $ rightId @(Average Rational) (+) 0
         describe "multiplication" $ do
-          it "associativity" . property $ isAssoc @(Average Int) (*)
-          it "commutative" . property $ isCommut @(Average Int) (*)
-          it "left identity" . property $ leftId @(Average Int) (*) 1
-          it "right identity" . property $ rightId @(Average Int) (*) 1
+          it "associativity" . property $ isAssoc @(Average Rational) (*)
+          it "commutative" . property $ isCommut @(Average Rational) (*)
+          it "left identity" . property $ leftId @(Average Rational) (*) 1
+          it "right identity" . property $ rightId @(Average Rational) (*) 1
       describe "laws for: vector space" $ do
-        it "associativity" . property $ isAssoc @(Average Int) (^+^)
-        it "commutative" . property $ isCommut @(Average Int) (^+^)
-        it "left identity" . property $ leftId @(Average Int) (^+^) zeroV
-        it "right identity" . property $ rightId @(Average Int) (^+^) zeroV
+        it "associativity" . property $ isAssoc @(Average Rational) (^+^)
+        it "commutative" . property $ isCommut @(Average Rational) (^+^)
+        it "left identity" . property $ leftId @(Average Rational) (^+^) zeroV
+        it "right identity" . property $ rightId @(Average Rational) (^+^) zeroV
         describe "closure" $ do
-          it "distributive: c u v" . property $ \(c, u, v :: Average Int) ->
+          it "distributive: c u v" . property $ \(c, u, v :: Average Rational) ->
             c *^ (u ^+^ v) =-= (c *^ u) ^+^ (c *^ v)
-          it "distributive: c d v" . property $ \(c, d, v :: Average Int) ->
+          it "distributive: c d v" . property $ \(c, d, v :: Average Rational) ->
             (c ^+^ d) *^ v =-= c *^ v ^+^ d *^ v
-          it "associativity" . property $ \(c, d, v :: Average Int) ->
+          it "associativity" . property $ \(c, d, v :: Average Rational) ->
             c *^ (d *^ v) =-= (c * d) *^ v
-          it "unitary" . property $ \(v :: Average Int) ->
+          it "unitary" . property $ \(v :: Average Rational) ->
             1 *^ v =-= v


### PR DESCRIPTION
Re #4:

> The list based monoid representation is not space efficient. This
implementation also leads towards a number of confusing and highly
opinionated instances. This new implementation is space efficient, ideal
for on-line algorithms and does not include possibly confusing/problematic
instances.

Unfortunately, storing a running sum means we can't just fmap or combine values anymore, because the stored values are magnified when averaged. I adressed this issue by changing from `Functor` to `MonoFunctor`, and performing the average before those operations.

It would also be possible to just _store_ the average right away; I've explored that in https://github.com/leftaroundabout/average/tree/refactor/weight-and-average. However that approach makes the `Monoid` instance quite inefficient, and we should probably prioritise keeping that efficient because it's the centerpiece of this package.